### PR TITLE
chore: upgrade cdk version

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -1,11 +1,6 @@
 {
   "dependencies": [
     {
-      "name": "@aws-cdk/aws-appsync-alpha",
-      "version": "2.55.1-alpha.0",
-      "type": "build"
-    },
-    {
       "name": "@types/jest",
       "version": "^27",
       "type": "build"
@@ -27,7 +22,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.55.1",
+      "version": "2.60.0",
       "type": "build"
     },
     {
@@ -116,13 +111,8 @@
       "type": "override"
     },
     {
-      "name": "@aws-cdk/aws-appsync-alpha",
-      "version": "2.55.1-alpha.0",
-      "type": "peer"
-    },
-    {
       "name": "aws-cdk-lib",
-      "version": "^2.55.1",
+      "version": "^2.60.0",
       "type": "peer"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -295,19 +295,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,13 +1,9 @@
 const { awscdk } = require('projen');
 
-// CDK and alpha package versions need to be in sync
-const CDK_VERSION = '2.55.1';
-const APPSYNC_ALPHA_VERSION = `${CDK_VERSION}-alpha.0`;
-
 const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Mitchell Valine',
   authorAddress: 'mitchellvaline@yahoo.com',
-  cdkVersion: CDK_VERSION,
+  cdkVersion: '2.60.0',
   defaultReleaseBranch: 'main',
   name: 'awscdk-appsync-utils',
   repositoryUrl: 'https://github.com/cdklabs/awscdk-appsync-utils.git',
@@ -15,10 +11,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
 
   // deps: [],                /* Runtime dependencies of this module. */
   // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */
-  devDeps: [
-    '@aws-cdk/aws-appsync-alpha',
-  ],
-  peerDeps: [`@aws-cdk/aws-appsync-alpha@${APPSYNC_ALPHA_VERSION}`],
   publishToMaven: {
     javaPackage: 'io.github.cdklabs.awscdk.appsync.utils',
     mavenGroupId: 'io.github.cdklabs',

--- a/API.md
+++ b/API.md
@@ -413,10 +413,10 @@ const resolvableFieldOptions: ResolvableFieldOptions = { ... }
 | <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.returnType">returnType</a></code> | <code><a href="#awscdk-appsync-utils.GraphqlType">GraphqlType</a></code> | The return type for this field. |
 | <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.args">args</a></code> | <code>{[ key: string ]: <a href="#awscdk-appsync-utils.GraphqlType">GraphqlType</a>}</code> | The arguments for this field. |
 | <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.directives">directives</a></code> | <code><a href="#awscdk-appsync-utils.Directive">Directive</a>[]</code> | the directives for this field. |
-| <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.dataSource">dataSource</a></code> | <code>@aws-cdk/aws-appsync-alpha.BaseDataSource</code> | The data source creating linked to this resolvable field. |
-| <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.pipelineConfig">pipelineConfig</a></code> | <code>@aws-cdk/aws-appsync-alpha.IAppsyncFunction[]</code> | configuration of the pipeline resolver. |
-| <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.requestMappingTemplate">requestMappingTemplate</a></code> | <code>@aws-cdk/aws-appsync-alpha.MappingTemplate</code> | The request mapping template for this resolver. |
-| <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.responseMappingTemplate">responseMappingTemplate</a></code> | <code>@aws-cdk/aws-appsync-alpha.MappingTemplate</code> | The response mapping template for this resolver. |
+| <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.dataSource">dataSource</a></code> | <code>aws-cdk-lib.aws_appsync.BaseDataSource</code> | The data source creating linked to this resolvable field. |
+| <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.pipelineConfig">pipelineConfig</a></code> | <code>aws-cdk-lib.aws_appsync.IAppsyncFunction[]</code> | configuration of the pipeline resolver. |
+| <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.requestMappingTemplate">requestMappingTemplate</a></code> | <code>aws-cdk-lib.aws_appsync.MappingTemplate</code> | The request mapping template for this resolver. |
+| <code><a href="#awscdk-appsync-utils.ResolvableFieldOptions.property.responseMappingTemplate">responseMappingTemplate</a></code> | <code>aws-cdk-lib.aws_appsync.MappingTemplate</code> | The response mapping template for this resolver. |
 
 ---
 
@@ -468,7 +468,7 @@ the directives for this field.
 public readonly dataSource: BaseDataSource;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.BaseDataSource
+- *Type:* aws-cdk-lib.aws_appsync.BaseDataSource
 - *Default:* no data source
 
 The data source creating linked to this resolvable field.
@@ -481,7 +481,7 @@ The data source creating linked to this resolvable field.
 public readonly pipelineConfig: IAppsyncFunction[];
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.IAppsyncFunction[]
+- *Type:* aws-cdk-lib.aws_appsync.IAppsyncFunction[]
 - *Default:* no pipeline resolver configuration An empty array or undefined prop will set resolver to be of type unit
 
 configuration of the pipeline resolver.
@@ -494,7 +494,7 @@ configuration of the pipeline resolver.
 public readonly requestMappingTemplate: MappingTemplate;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.MappingTemplate
+- *Type:* aws-cdk-lib.aws_appsync.MappingTemplate
 - *Default:* No mapping template
 
 The request mapping template for this resolver.
@@ -507,7 +507,7 @@ The request mapping template for this resolver.
 public readonly responseMappingTemplate: MappingTemplate;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.MappingTemplate
+- *Type:* aws-cdk-lib.aws_appsync.MappingTemplate
 - *Default:* No mapping template
 
 The response mapping template for this resolver.
@@ -550,7 +550,7 @@ the object types for this union type.
 
 ### CodeFirstSchema <a name="CodeFirstSchema" id="awscdk-appsync-utils.CodeFirstSchema"></a>
 
-- *Implements:* @aws-cdk/aws-appsync-alpha.ISchema
+- *Implements:* aws-cdk-lib.aws_appsync.ISchema
 
 #### Initializers <a name="Initializers" id="awscdk-appsync-utils.CodeFirstSchema.Initializer"></a>
 
@@ -715,7 +715,7 @@ Called when the GraphQL Api is initialized to allow this object to bind to the s
 
 ###### `api`<sup>Required</sup> <a name="api" id="awscdk-appsync-utils.CodeFirstSchema.bind.parameter.api"></a>
 
-- *Type:* @aws-cdk/aws-appsync-alpha.IGraphqlApi
+- *Type:* aws-cdk-lib.aws_appsync.IGraphqlApi
 
 The binding GraphQL Api.
 
@@ -723,7 +723,7 @@ The binding GraphQL Api.
 
 ###### `_options`<sup>Optional</sup> <a name="_options" id="awscdk-appsync-utils.CodeFirstSchema.bind.parameter._options"></a>
 
-- *Type:* @aws-cdk/aws-appsync-alpha.SchemaBindOptions
+- *Type:* aws-cdk-lib.aws_appsync.SchemaBindOptions
 
 ---
 
@@ -874,7 +874,7 @@ the mutation fields to link to.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#awscdk-appsync-utils.Directive.property.mode">mode</a></code> | <code>@aws-cdk/aws-appsync-alpha.AuthorizationType</code> | The authorization type of this directive. |
+| <code><a href="#awscdk-appsync-utils.Directive.property.mode">mode</a></code> | <code>aws-cdk-lib.aws_appsync.AuthorizationType</code> | The authorization type of this directive. |
 | <code><a href="#awscdk-appsync-utils.Directive.property.mutationFields">mutationFields</a></code> | <code>string[]</code> | Mutation fields for a subscription directive. |
 
 ---
@@ -885,7 +885,7 @@ the mutation fields to link to.
 public readonly mode: AuthorizationType;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.AuthorizationType
+- *Type:* aws-cdk-lib.aws_appsync.AuthorizationType
 - *Default:* not an authorization directive
 
 The authorization type of this directive.
@@ -1079,7 +1079,7 @@ Generate the directives for this field.
 
 ###### `modes`<sup>Optional</sup> <a name="modes" id="awscdk-appsync-utils.Field.directivesToString.parameter.modes"></a>
 
-- *Type:* @aws-cdk/aws-appsync-alpha.AuthorizationType[]
+- *Type:* aws-cdk-lib.aws_appsync.AuthorizationType[]
 
 ---
 
@@ -1557,7 +1557,7 @@ Generate the directives for this field.
 
 ###### `_modes`<sup>Optional</sup> <a name="_modes" id="awscdk-appsync-utils.GraphqlType.directivesToString.parameter._modes"></a>
 
-- *Type:* @aws-cdk/aws-appsync-alpha.AuthorizationType[]
+- *Type:* aws-cdk-lib.aws_appsync.AuthorizationType[]
 
 ---
 
@@ -2302,7 +2302,7 @@ Generate the string of this object type.
 | <code><a href="#awscdk-appsync-utils.ObjectType.property.name">name</a></code> | <code>string</code> | the name of this type. |
 | <code><a href="#awscdk-appsync-utils.ObjectType.property.directives">directives</a></code> | <code><a href="#awscdk-appsync-utils.Directive">Directive</a>[]</code> | the directives for this object type. |
 | <code><a href="#awscdk-appsync-utils.ObjectType.property.interfaceTypes">interfaceTypes</a></code> | <code><a href="#awscdk-appsync-utils.InterfaceType">InterfaceType</a>[]</code> | The Interface Types this Object Type implements. |
-| <code><a href="#awscdk-appsync-utils.ObjectType.property.resolvers">resolvers</a></code> | <code>@aws-cdk/aws-appsync-alpha.Resolver[]</code> | The resolvers linked to this data source. |
+| <code><a href="#awscdk-appsync-utils.ObjectType.property.resolvers">resolvers</a></code> | <code>aws-cdk-lib.aws_appsync.Resolver[]</code> | The resolvers linked to this data source. |
 
 ---
 
@@ -2362,7 +2362,7 @@ The Interface Types this Object Type implements.
 public readonly resolvers: Resolver[];
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.Resolver[]
+- *Type:* aws-cdk-lib.aws_appsync.Resolver[]
 
 The resolvers linked to this data source.
 
@@ -2423,7 +2423,7 @@ Generate the directives for this field.
 
 ###### `modes`<sup>Optional</sup> <a name="modes" id="awscdk-appsync-utils.ResolvableField.directivesToString.parameter.modes"></a>
 
-- *Type:* @aws-cdk/aws-appsync-alpha.AuthorizationType[]
+- *Type:* aws-cdk-lib.aws_appsync.AuthorizationType[]
 
 ---
 
@@ -2991,7 +2991,7 @@ Generate the directives for this field.
 
 ###### `modes`<sup>Optional</sup> <a name="modes" id="awscdk-appsync-utils.IField.directivesToString.parameter.modes"></a>
 
-- *Type:* @aws-cdk/aws-appsync-alpha.AuthorizationType[]
+- *Type:* aws-cdk-lib.aws_appsync.AuthorizationType[]
 
 the authorization modes of the graphql api.
 
@@ -3158,7 +3158,7 @@ Generate the string of this object type.
 | <code><a href="#awscdk-appsync-utils.IIntermediateType.property.directives">directives</a></code> | <code><a href="#awscdk-appsync-utils.Directive">Directive</a>[]</code> | the directives for this object type. |
 | <code><a href="#awscdk-appsync-utils.IIntermediateType.property.interfaceTypes">interfaceTypes</a></code> | <code><a href="#awscdk-appsync-utils.InterfaceType">InterfaceType</a>[]</code> | The Interface Types this Intermediate Type implements. |
 | <code><a href="#awscdk-appsync-utils.IIntermediateType.property.intermediateType">intermediateType</a></code> | <code><a href="#awscdk-appsync-utils.IIntermediateType">IIntermediateType</a></code> | the intermediate type linked to this attribute (i.e. an interface or an object). |
-| <code><a href="#awscdk-appsync-utils.IIntermediateType.property.resolvers">resolvers</a></code> | <code>@aws-cdk/aws-appsync-alpha.Resolver[]</code> | The resolvers linked to this data source. |
+| <code><a href="#awscdk-appsync-utils.IIntermediateType.property.resolvers">resolvers</a></code> | <code>aws-cdk-lib.aws_appsync.Resolver[]</code> | The resolvers linked to this data source. |
 
 ---
 
@@ -3231,7 +3231,7 @@ the intermediate type linked to this attribute (i.e. an interface or an object).
 public readonly resolvers: Resolver[];
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.Resolver[]
+- *Type:* aws-cdk-lib.aws_appsync.Resolver[]
 
 The resolvers linked to this data source.
 

--- a/package.json
+++ b/package.json
@@ -39,12 +39,11 @@
     "organization": false
   },
   "devDependencies": {
-    "@aws-cdk/aws-appsync-alpha": "2.55.1-alpha.0",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.55.1",
+    "aws-cdk-lib": "2.60.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
@@ -64,8 +63,7 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-appsync-alpha": "2.55.1-alpha.0",
-    "aws-cdk-lib": "^2.55.1",
+    "aws-cdk-lib": "^2.60.0",
     "constructs": "^10.0.5"
   },
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { SchemaBindOptions, ISchema, ISchemaConfig, IGraphqlApi } from '@aws-cdk/aws-appsync-alpha';
 import { Lazy } from 'aws-cdk-lib';
+import { SchemaBindOptions, ISchema, ISchemaConfig, IGraphqlApi } from 'aws-cdk-lib/aws-appsync';
 import { shapeAddition } from './private';
 import { IIntermediateType } from './schema-base';
 import { Field, ResolvableField } from './schema-field';

--- a/src/private.ts
+++ b/src/private.ts
@@ -1,4 +1,4 @@
-import { AuthorizationType } from '@aws-cdk/aws-appsync-alpha';
+import { AuthorizationType } from 'aws-cdk-lib/aws-appsync';
 import { Directive } from './schema-base';
 import { InterfaceType } from './schema-intermediate';
 

--- a/src/schema-base.ts
+++ b/src/schema-base.ts
@@ -1,4 +1,4 @@
-import { Resolver, AuthorizationType, IGraphqlApi } from '@aws-cdk/aws-appsync-alpha';
+import { Resolver, AuthorizationType, IGraphqlApi } from 'aws-cdk-lib/aws-appsync';
 import { BaseTypeOptions, GraphqlType, ResolvableFieldOptions } from './schema-field';
 import { InterfaceType } from './schema-intermediate';
 

--- a/src/schema-field.ts
+++ b/src/schema-field.ts
@@ -1,4 +1,4 @@
-import { IAppsyncFunction, BaseDataSource, AuthorizationType, MappingTemplate } from '@aws-cdk/aws-appsync-alpha';
+import { IAppsyncFunction, BaseDataSource, AuthorizationType, MappingTemplate } from 'aws-cdk-lib/aws-appsync';
 import { Type, IField, IIntermediateType, Directive } from './schema-base';
 
 /**

--- a/src/schema-intermediate.ts
+++ b/src/schema-intermediate.ts
@@ -1,4 +1,4 @@
-import { Resolver, IGraphqlApi, AuthorizationType, GraphqlApi } from '@aws-cdk/aws-appsync-alpha';
+import { Resolver, IGraphqlApi, AuthorizationType, GraphqlApi } from 'aws-cdk-lib/aws-appsync';
 import { shapeAddition } from './private';
 import { Directive, IField, IIntermediateType, AddFieldOptions } from './schema-base';
 import { BaseTypeOptions, GraphqlType, ResolvableFieldOptions, ResolvableField } from './schema-field';

--- a/test/appsync-code-first.test.ts
+++ b/test/appsync-code-first.test.ts
@@ -1,6 +1,6 @@
-import { GraphqlApi } from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import { GraphqlApi } from 'aws-cdk-lib/aws-appsync';
 import { CodeFirstSchema, Directive, Field, InterfaceType, ObjectType, ResolvableField } from '../src';
 import * as t from './scalar-type-defintions';
 

--- a/test/appsync-directives.test.ts
+++ b/test/appsync-directives.test.ts
@@ -1,6 +1,6 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import { CodeFirstSchema, Directive, Field, InterfaceType, ObjectType, ResolvableField } from '../src';
 import * as t from './scalar-type-defintions';

--- a/test/appsync-enum-type.test.ts
+++ b/test/appsync-enum-type.test.ts
@@ -1,6 +1,6 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { CodeFirstSchema, EnumType, ObjectType } from '../src';
 import * as t from './scalar-type-defintions';
 

--- a/test/appsync-input-types.test.ts
+++ b/test/appsync-input-types.test.ts
@@ -1,6 +1,6 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { CodeFirstSchema, InputType, ObjectType } from '../src';
 import * as t from './scalar-type-defintions';
 

--- a/test/appsync-interface-type.test.ts
+++ b/test/appsync-interface-type.test.ts
@@ -1,6 +1,6 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { CodeFirstSchema, Directive, Field, InterfaceType, ObjectType, ResolvableField } from '../src';
 import * as t from './scalar-type-defintions';
 

--- a/test/appsync-object-type.test.ts
+++ b/test/appsync-object-type.test.ts
@@ -1,6 +1,6 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { CodeFirstSchema, Directive, Field, InterfaceType, ObjectType, ResolvableField } from '../src';
 import * as t from './scalar-type-defintions';
 

--- a/test/appsync-scalar-type.test.ts
+++ b/test/appsync-scalar-type.test.ts
@@ -1,6 +1,6 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { CodeFirstSchema, ObjectType } from '../src';
 import * as t from './scalar-type-defintions';
 

--- a/test/appsync-schema.test.ts
+++ b/test/appsync-schema.test.ts
@@ -1,6 +1,6 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { CodeFirstSchema, ObjectType, ResolvableField } from '../src';
 import * as t from './scalar-type-defintions';
 

--- a/test/appsync-union-types.test.ts
+++ b/test/appsync-union-types.test.ts
@@ -1,6 +1,6 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { CodeFirstSchema, Field, InterfaceType, ObjectType, ResolvableField, UnionType } from '../src';
 import * as t from './scalar-type-defintions';
 

--- a/test/integ.graphql-schema.ts
+++ b/test/integ.graphql-schema.ts
@@ -1,5 +1,5 @@
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as cdk from 'aws-cdk-lib';
+import * as appsync from 'aws-cdk-lib/aws-appsync';
 import * as db from 'aws-cdk-lib/aws-dynamodb';
 import { CodeFirstSchema, Directive, EnumType, Field, InputType, InterfaceType, ObjectType, ResolvableField, UnionType } from '../src';
 import * as ObjectTypeDefs from './object-type-definitions';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.30":
+"@aws-cdk/asset-awscli-v1@^2.2.49":
   version "2.2.49"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.49.tgz#af7618a3a39bf103f82d7aa396efa50e6ae79092"
   integrity sha512-Qd5bdLlC/sphWQQPNn7etKXWCh+fij7DWxtkIwvhhZ+LM6UEApGLS8sBLBQcRO2ZQdEuNb+zeClUy+3DNojfeg==
@@ -24,11 +24,6 @@
   version "2.0.38"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.38.tgz#6765bef55f95220c52decb4adba8f75c1817b0f7"
   integrity sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ==
-
-"@aws-cdk/aws-appsync-alpha@2.55.1-alpha.0":
-  version "2.55.1-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appsync-alpha/-/aws-appsync-alpha-2.55.1-alpha.0.tgz#d38bd350553e6c5ebb6d3c9d95be2ff55d000419"
-  integrity sha512-mUTBnXY6Dz3ZtvC8APA8MHlgj5a/lG/dLeaCoz66VBTI0Gq80NZEJVZjpiS50k/rgJRIVTksH2CfBwqjuJcDfw==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
@@ -1244,18 +1239,18 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.55.1:
-  version "2.55.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.55.1.tgz#4044118ff7a38952abf7f10035bcec5dd1a6f8e9"
-  integrity sha512-v0MhL6RqazQ2HKj9TXJvXKQcQNIDYeRzcOJ2xB2Usz56xodArc2goLu2P51X5J84xOO4w2AgNaWMCBzd7MbyOQ==
+aws-cdk-lib@2.60.0:
+  version "2.60.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.60.0.tgz#e96400640aca6cf326bd01b02866a157110e6432"
+  integrity sha512-AttvwGmS1TDiOgkskrRw4lQoDwoyzjb+M0iMzHEa75xDz7hkykudNVEvWOfcbid+rzkgfLQyElwtf/oz6m+O9A==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.30"
+    "@aws-cdk/asset-awscli-v1" "^2.2.49"
     "@aws-cdk/asset-kubectl-v20" "^2.1.1"
     "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.38"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
-    ignore "^5.2.1"
+    ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
     punycode "^2.1.1"
@@ -3133,7 +3128,7 @@ ignore-walk@^6.0.0:
   dependencies:
     minimatch "^5.0.1"
 
-ignore@^5.2.0, ignore@^5.2.1:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==


### PR DESCRIPTION
Upgrade to using `aws-cdk-lib@2.60.0` which has appsync constructs bundled in instead of using the separate `@aws-cdk/aws-appsync-alpha` package.

Fixes #8