### PR TITLE
fix: update bundle command to export handler properly

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -87,7 +87,7 @@
       "description": "Only compile",
       "steps": [
         {
-          "exec": "esbuild ./src/mergeSourceApiSchemaHandler/index.ts --bundle --outfile=./lib/mergeSourceApiSchemaHandler/index.js"
+          "exec": "esbuild ./src/mergeSourceApiSchemaHandler/index.ts --bundle --outfile=./lib/mergeSourceApiSchemaHandler/index.js --platform=node --format=cjs"
         },
         {
           "exec": "jsii --silence-warnings=reserved-word"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -49,7 +49,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
 });
 
 project.compileTask.prependExec(
-  'esbuild ./src/mergeSourceApiSchemaHandler/index.ts --bundle --outfile=./lib/mergeSourceApiSchemaHandler/index.js',
+  'esbuild ./src/mergeSourceApiSchemaHandler/index.ts --bundle --outfile=./lib/mergeSourceApiSchemaHandler/index.js --platform=node --format=cjs',
 );
 
 project.addDevDeps('esbuild');


### PR DESCRIPTION
Fixes an additional issue where Lambda handler was not being properly exported. We will remove the need to bundle the client-appsync module in the future once Lambda runtime is updated to a more recent version of SDK v3. 