### PR TITLE
Fix handling of empty args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ junit.xml
 .jsii
 tsconfig.json
 !/API.md
+.idea

--- a/src/schema-field.ts
+++ b/src/schema-field.ts
@@ -385,8 +385,9 @@ export class Field extends GraphqlType implements IField {
    */
   public argsToString(): string {
     if (!this.fieldOptions || !this.fieldOptions.args) { return ''; }
-    return Object.keys(this.fieldOptions.args).reduce((acc, key) =>
-      `${acc}${key}: ${this.fieldOptions?.args?.[key].toString()} `, '(').slice(0, -1) + ')';
+    const argString = Object.keys(this.fieldOptions.args).reduce((acc, key) =>
+      `${acc}${key}: ${this.fieldOptions?.args?.[key].toString()} `, '(').slice(0, -1);
+    return argString === '' ? argString : argString + ')';
   }
 
   /**

--- a/test/appsync-schema.test.ts
+++ b/test/appsync-schema.test.ts
@@ -81,6 +81,43 @@ describe('basic testing schema definition mode `code`', () => {
     });
   });
 
+  test('definition mode `code` allows for api to addQuery with empty args', () => {
+    // WHEN
+    const schema = new CodeFirstSchema();
+    new appsync.GraphqlApi(stack, 'API', {
+      name: 'demo',
+      schema,
+    });
+    schema.addQuery('test', new ResolvableField({
+      returnType: t.string,
+      args: {},
+    }));
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::AppSync::GraphQLSchema', {
+      Definition: 'schema {\n  query: Query\n}\ntype Query {\n  test: String\n}\n',
+    });
+  });
+
+  test('definition mode `code` allows for api to addQuery with args', () => {
+    // WHEN
+    const schema = new CodeFirstSchema();
+    new appsync.GraphqlApi(stack, 'API', {
+      name: 'demo',
+      schema,
+    });
+    schema.addQuery('test', new ResolvableField({
+      returnType: t.string,
+      args: { id: t.string },
+    }));
+
+    // THEN
+    Template.fromStack(stack).hasResourceProperties('AWS::AppSync::GraphQLSchema', {
+      Definition: 'schema {\n  query: Query\n}\ntype Query {\n  test(id: String): String\n}\n',
+    });
+  });
+
+
   test('definition mode `code` allows for schema to addMutation', () => {
     // WHEN
     const schema = new CodeFirstSchema();


### PR DESCRIPTION
Fixes #
Handles the case where args is passed as `{}`, which currently results in a single closing parenthesis. 